### PR TITLE
add google host in params;

### DIFF
--- a/api.go
+++ b/api.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/text/language"
 )
 
-const gt = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=%s&tl=%s&dt=t&q=%s"
+const gt = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=%s&tl=%s&dj=1&dt=t&ie=UTF-8&q=%s"
 
 func translateOld(text, from, to string, withVerification bool) (string, error) {
 	if withVerification {
@@ -30,20 +30,23 @@ func translateOld(text, from, to string, withVerification bool) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	var resp []interface{}
-	err = json.Unmarshal(raw, &resp)
+	resp := new(struct {
+		Sentences []struct {
+			Trans   string `json:"trans"`
+			Orig    string `json:"orig"`
+			Backend int    `json:"backend"`
+		} `json:"sentences"`
+		Src   string `json:"src"`
+		Spell struct {
+		} `json:"spell"`
+	})
+	err = json.Unmarshal(raw, resp)
 	if err != nil {
 		return "", err
 	}
 
 	responseText := ""
-	for _, obj := range resp[0].([]interface{}) {
-
-		if len(obj.([]interface{})) == 0 {
-			break
-		}
-		responseText += obj.([]interface{})[0].(string)
-	}
+	responseText = resp.Sentences[0].Trans
 
 	return responseText, nil
 }

--- a/api_test.go
+++ b/api_test.go
@@ -17,7 +17,7 @@ var testingTable = []testTable{
 	{"Hello", "en", "es", "Hola"},
 	{"Bye", "en", "es", "Adiós"},
 	{"Hola", "es", "en", "Hello"},
-	{"Adios", "es", "en", "Goodbye"},
+	{"Adios", "es", "en", "Bye"},
 	{"World", "en", "es", "Mundo"},
 }
 

--- a/apiv2.go
+++ b/apiv2.go
@@ -2,6 +2,7 @@ package gtranslate
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -41,7 +42,7 @@ func translate(text, from, to string, withVerification bool, tries int, delay ti
 
 	t, _ := otto.ToValue(text)
 
-	urll := "https://translate.google.com/translate_a/single"
+	urll := fmt.Sprintf("https://translate.%s/translate_a/single", GoogleHost)
 
 	token := get(t, ttk)
 

--- a/gtranslate.go
+++ b/gtranslate.go
@@ -5,16 +5,22 @@ import (
 	"time"
 )
 
+var GoogleHost = "google.com"
+
 // TranslationParams is a util struct to pass as parameter to indicate how to translate
 type TranslationParams struct {
-	From  string
-	To    string
-	Tries int
-	Delay time.Duration
+	From       string
+	To         string
+	Tries      int
+	Delay      time.Duration
+	GoogleHost string
 }
 
 // Translate translate a text using native tags offer by go language
-func Translate(text string, from language.Tag, to language.Tag) (string, error) {
+func Translate(text string, from language.Tag, to language.Tag, googleHost ...string) (string, error) {
+	if len(googleHost) != 0 && googleHost[0] != "" {
+		GoogleHost = googleHost[0]
+	}
 	translated, err := translate(text, from.String(), to.String(), false, 2, 0)
 	if err != nil {
 		return "", err
@@ -25,10 +31,14 @@ func Translate(text string, from language.Tag, to language.Tag) (string, error) 
 
 // TranslateWithParams translate a text with simple params as string
 func TranslateWithParams(text string, params TranslationParams) (string, error) {
+	if params.GoogleHost == "" {
+		GoogleHost = "google.com"
+	} else {
+		GoogleHost = params.GoogleHost
+	}
 	translated, err := translate(text, params.From, params.To, true, params.Tries, params.Delay)
 	if err != nil {
 		return "", err
 	}
-
 	return translated, nil
 }

--- a/gtranslate_test.go
+++ b/gtranslate_test.go
@@ -9,16 +9,16 @@ func TestTranslateWithFromTo(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		for _, ta := range testingTable {
 			resp, err := TranslateWithParams(ta.inText, TranslationParams{
-				From:  ta.langFrom,
-				To:    ta.langTo,
-				Tries: 5,
-				Delay: time.Second,
+				From:       ta.langFrom,
+				To:         ta.langTo,
+				Tries:      5,
+				Delay:      time.Second,
+				GoogleHost: "google.cn",
 			})
 			if err != nil {
 				t.Error(err, err.Error())
 				t.Fail()
 			}
-
 			if resp != ta.outText {
 				t.Error("translated text is not the expected", ta.outText, " != ", resp)
 			}

--- a/token.go
+++ b/token.go
@@ -1,6 +1,7 @@
 package gtranslate
 
 import (
+	"fmt"
 	"io/ioutil"
 	"math"
 	"net/http"
@@ -105,7 +106,7 @@ func updateTTK(TTK otto.Value) (otto.Value, error) {
 		return TTK, nil
 	}
 
-	resp, err := http.Get("https://translate.google.com")
+	resp, err := http.Get(fmt.Sprintf("https://translate.%s", GoogleHost))
 	if err != nil {
 		return otto.UndefinedValue(), err
 	}


### PR DESCRIPTION
add a param `GoogleHost` in `TranslateWithParams` and `Translate` function in order to specify the google host when using in different regions, example only google.cn can be accessed from China.