### PR TITLE
Add Mutex to avoid race condition in otto package

### DIFF
--- a/token.go
+++ b/token.go
@@ -15,7 +15,12 @@ import (
 
 var vm = otto.New()
 
+var mu sync.Mutex
+
 func sM(a otto.Value, TTK ...otto.Value) (otto.Value, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	
 	err := vm.Set("x", a)
 	if err != nil {
 		return otto.UndefinedValue(), err


### PR DESCRIPTION
Otto package is not well designed and has multiple race conditions. Therefore, if we run the code in a concurrent environment, it will crash. To solve this issue, it is suggested to add a Mutex to sM.